### PR TITLE
More readable search, additional Python highlighting and integrated terminal theming

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # fairyfloss
 All credit goes to sailorhg on github for their awesome theme [fairyfloss](https://github.com/sailorhg/fairyfloss)!✨
 
-I'm responsible for everything outside of the syntax general syntax highlighting.
+I'm responsible for everything outside of the general syntax highlighting.
 
 Languages with modifications specific to vscode:
 

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ Languages with modifications specific to vscode:
 * Markdown
 * Java
 * Clojure
+* Python
 
 Please report any issues with syntax highlighting or ideas to improve anything!
 

--- a/themes/fairyfloss-color-theme.json
+++ b/themes/fairyfloss-color-theme.json
@@ -345,10 +345,31 @@
 				"source.python keyword.operator.comparison.python"
 			],
 			"settings": {
+				"foreground": "#C5A3FF"
+			}
+		},
+		{
+			"name": "Python decorators",
+			"scope": [
+				"source.python meta.function.decorator.python",
+				"source.python entity.name.function.decorator.python",
+			],
+			"settings": {
 				"fontStyle": "italic",
 				"foreground": "#C2FFDF"
 			}
 		},
+		{
+			"name": "Python function parameter annotation",
+			"scope": [
+				"source.python meta.function.parameters.python",
+				"source.python keyword.operator.unpacking.parameter.python",
+			],
+			"settings": {
+				"fontStyle": "italic",
+				"foreground": "#C2FFDF"
+			}
+		}
 	],
 	"colors": {
 		"editor.background": "#5A5475",

--- a/themes/fairyfloss-color-theme.json
+++ b/themes/fairyfloss-color-theme.json
@@ -410,8 +410,11 @@
 		"titleBar.inactiveBackground": "#3a3553",
 		"titleBar.inactiveForeground": "#b9b9b9",
 		"terminal.ansiBrightBlack": "#C2FFDF",
+		"terminal.ansiBrightBlue": "#FFF352",
+		"terminal.ansiBrightCyan": "#F8F8F2",
+		"terminal.ansiBrightRed": "#FF857F",
+		"terminal.ansiGreen": "#AFECAD",
 		"terminal.ansiRed": "#FF857F",
-		"terminal.ansiGreen": "#AFECAD"
 	},
 	"name": "fairyfloss"
 }

--- a/themes/fairyfloss-color-theme.json
+++ b/themes/fairyfloss-color-theme.json
@@ -320,6 +320,35 @@
 				"foreground": "#FF857F"
 			}
 		},
+		{
+			"name": "Python docstring",
+			"scope": [
+				"source.python string.quoted.docstring.multi.python",
+			],
+			"settings": {
+				"foreground": "#E6C000"
+			}
+		},
+		{
+			"name": "Python function name that matches builtins",
+			"scope": [
+				"source.python meta.function.python support.function.builtin.python",
+			],
+			"settings": {
+				"foreground": "#FFF352"
+			}
+		},
+		{
+			"name": "Python logical operator",
+			"scope": [
+				"source.python keyword.operator.logical.python",
+				"source.python keyword.operator.comparison.python"
+			],
+			"settings": {
+				"fontStyle": "italic",
+				"foreground": "#C2FFDF"
+			}
+		},
 	],
 	"colors": {
 		"editor.background": "#5A5475",

--- a/themes/fairyfloss-color-theme.json
+++ b/themes/fairyfloss-color-theme.json
@@ -379,6 +379,8 @@
 		"editorRuler.foreground": "#A8757B",
 		"editor.lineHighlightBackground": "#716799",
 		"editor.selectionBackground": "#8077A8",
+		"editor.findMatchHighlightBackground":"#AD5877",
+		"editor.findMatchBackground":"#464258",
 		"editorLineNumber.foreground": "#F8F8F2",
 		"sideBar.background": "#514C66",
 		"sideBar.dropBackground": "#464258",


### PR DESCRIPTION
Thank you for looking at another PR! I apologize for not giving myself another day with the theme before opening up https://github.com/nopjmp/vscode-fairyfloss/pull/2.

Here are a few more changes I ended up making in my local settings (in all the images, "before" is above and "after" is below). Some of these are more debatable than others- definitely push back if you feel like I'm not improving the readability!

### More readable search
I particularly wanted higher contrast on the currently-selected / highlighted result, but I figured I'd make the other highlight one of the theme colours while I was at it:

![before_and_after_search](https://user-images.githubusercontent.com/7595169/66246206-6510f000-e6c7-11e9-86c0-a5dbe3cba892.png)

### Additional Python-specific highlighting

Decorators are a single colour:
![before_and_after_decorator](https://user-images.githubusercontent.com/7595169/66246109-cab0ac80-e6c6-11e9-8175-bd4ec1804245.png)

Function names that match builtins still look like function names, docstrings look like comments rather than strings:
![before_and_after_docstring_special](https://user-images.githubusercontent.com/7595169/66246090-b1a7fb80-e6c6-11e9-93f2-a3662e9d1a48.png)

Logical operators are highlighted differently than keywords like `if` (not as obvious a win in this screenshot, but matches the syntax highlighting I'm used to from built-in themes):
![before_and_after_logical_operator](https://user-images.githubusercontent.com/7595169/66246142-faf84b00-e6c6-11e9-86ad-50beaa09235d.png)

Function parameters / type annotations involve fewer colours:
![before_and_after_function_params](https://user-images.githubusercontent.com/7595169/66246151-06e40d00-e6c7-11e9-9672-f48ca83c3280.png)

### Terminal theming
I haven't overridden all of the ANSI colours, since I'm only converting them to theme colours as I encounter them. I encountered a few more, though! For example:

![before_and_after_terminal](https://user-images.githubusercontent.com/7595169/66246227-925d9e00-e6c7-11e9-85d4-98df25ca3f3e.png)