### PR TITLE
Specify colors for search

### DIFF
--- a/themes/fairyfloss-color-theme.json
+++ b/themes/fairyfloss-color-theme.json
@@ -75,6 +75,9 @@
 		"editor.foreground": "#F8F8F2",
 		"editor.lineHighlightBackground": "#716799",
 		"editor.selectionBackground": "#8077A8",
+		"editor.findMatchBackground":"#8077A8", // Color of the current search match - same as selection
+		"editor.findMatchHighlightBackground":"#8077A800", // Transparent highlight of all search matches - we use a border instead.
+		"editor.findMatchHighlightBorder":"#F8F8F2", // Border color for all search matches
 		"editorLink.activeForeground": "#C990A5",
 		"editorLineNumber.foreground": "#F8F8F2",
 		"editorWhitespace.foreground": "#A8757B",


### PR DESCRIPTION
This adds styles for search - I (mostly) mimicked what sublimetext does for search with this theme, which is a light border for all matches and a background color for the current match, but I used the selectedText background color instead of the yellow that sublimetext does.

Screenshots from VSCode 1.57.0 on Ubuntu.

Before:
![fairyfloss-search-colors-before](https://user-images.githubusercontent.com/802412/123162914-c7c79380-d436-11eb-9667-1a39c5de8d89.png)

After:
![fairyfloss-search-colors-after](https://user-images.githubusercontent.com/802412/123162922-ca29ed80-d436-11eb-9143-542e01617ee0.png)
